### PR TITLE
Changed default shell from bash, to user shell

### DIFF
--- a/nemo-terminal/src/org.nemo.extensions.nemo-terminal.gschema.xml
+++ b/nemo-terminal/src/org.nemo.extensions.nemo-terminal.gschema.xml
@@ -41,7 +41,7 @@
 	    </key>
 	    
 	    <key name="terminal-shell" type="s">
-	       <default>"/bin/bash"</default>
+	       <default>""</default>
 	        <summary>Shell executable</summary>
 	        <description>Path to the shell executable nemo-terminal should use. Blank indicates shell will be user's default. Note that all other default parameters assume a bash-like shell.</description>
 	    </key>


### PR DESCRIPTION
As per the terminal-shell key's description, leaving key blank will result in nemo-terminal using user-shell, rather than defaulting to bash. All other function, such as  the change-directory-command, remain in tact.

resolves #141
